### PR TITLE
Refactoring: 게임엔진 로직 분리(진행중)

### DIFF
--- a/src/utils/detectAttackCollision.js
+++ b/src/utils/detectAttackCollision.js
@@ -1,0 +1,27 @@
+import { Dimensions } from "react-native";
+import entityInfo from "../entities/entitiesInfo";
+
+const WINDOW_HEIGHT = Dimensions.get("window").height;
+
+export default function detectAttackCollision({ entities, Matter, dispatch }) {
+  const boss = entities.boss1?.body;
+  const player = entities.player.body;
+  const { stage } = entities;
+  const attackNumber = entityInfo[stage].attack.number;
+  const attackArray = Array.from({ length: attackNumber }, (_, i) => i);
+
+  attackArray.forEach((entityNum) => {
+    const attack = entities[`attack${entityNum + 1}`].body;
+    const hit = Matter.Collision.collides(boss, attack);
+
+    if (hit) {
+      dispatch({ type: "hit_boss", payload: entityNum + 1 });
+      Matter.Body.setPosition(attack, {
+        x: player.position.x,
+        y: -WINDOW_HEIGHT,
+      });
+
+      entityInfo[stage].boss.specifics[1].HP -= 1;
+    }
+  });
+}

--- a/src/utils/killMonster.js
+++ b/src/utils/killMonster.js
@@ -1,0 +1,40 @@
+import entityInfo from "../entities/entitiesInfo";
+import makeReflectionAngle from "./physicsUtils/makeReflectionAngle";
+
+export default function killMonster({
+  Matter,
+  entities,
+  num,
+  dispatch,
+  collision,
+}) {
+  const player = entities.player.body;
+  const monsterEntity = entities[`monster${num + 1}`].body;
+  const { world } = entities.physics;
+  const { stage } = entities;
+
+  Matter.Body.setPosition(monsterEntity, {
+    x: monsterEntity.position.x + player.velocity.x * 2,
+    y: monsterEntity.position.y + player.velocity.y * 2,
+  });
+
+  const reflectionAngle = makeReflectionAngle(collision, player);
+
+  Matter.World.remove(world, monsterEntity);
+  entityInfo[stage].monster.specifics[num + 1].alive = false;
+
+  dispatch({
+    type: "kill_monster",
+    payload: {
+      number: num + 1,
+      x:
+        Math.cos(reflectionAngle) * -player.velocity.x -
+        Math.sin(reflectionAngle) * -player.velocity.y +
+        player.velocity.x,
+      y:
+        Math.sin(reflectionAngle) * -player.velocity.x +
+        Math.cos(reflectionAngle) * -player.velocity.y +
+        player.velocity.y,
+    },
+  });
+}

--- a/src/utils/physicsUtils/bossUtils/setMonsterMissile.js
+++ b/src/utils/physicsUtils/bossUtils/setMonsterMissile.js
@@ -1,5 +1,6 @@
 import { Dimensions } from "react-native";
 import entityInfo from "../../../entities/entitiesInfo";
+import setPositionOfPlayer from "./setPositionOfPlayer";
 
 const WINDOW_HEIGHT = Dimensions.get("window").height;
 const FLOOR_WIDTH = 32;
@@ -48,5 +49,27 @@ export const setThrowPositionTimely = ({ entities, Matter }) => {
       x: entities.boss1.body.bounds.max.x,
       y: entities.boss1.body.bounds.max.y,
     });
+  }
+};
+
+export const setThrowItemPositionTimely = ({ entities, Matter }) => {
+  const { stage } = entities;
+  const attackSpecific = entityInfo[stage].attack.specifics;
+  const attackPositionTimer = entityInfo[stage].attack.specifics[1].moved;
+
+  if (
+    attackPositionTimer > (GAME_HEIGHT / 3) * 1 &&
+    attackSpecific[2].onPosition === false
+  ) {
+    attackSpecific[2].onPosition = true;
+    setPositionOfPlayer({ Matter, entities, entity: "attack2" });
+  }
+
+  if (
+    attackPositionTimer > (GAME_HEIGHT / 3) * 2 &&
+    attackSpecific[3].onPosition === false
+  ) {
+    attackSpecific[3].onPosition = true;
+    setPositionOfPlayer({ Matter, entities, entity: "attack3" });
   }
 };

--- a/src/utils/physicsUtils/bossUtils/setPositionOfPlayer.js
+++ b/src/utils/physicsUtils/bossUtils/setPositionOfPlayer.js
@@ -1,0 +1,8 @@
+export default function setPositionOfPlayer({ Matter, entities, entity }) {
+  const player = entities.player.body;
+
+  Matter.Body.setPosition(entities[entity].body, {
+    x: player.position.x,
+    y: player.position.y - player.circleRadius,
+  });
+}

--- a/src/utils/physicsUtils/bossUtils/settingBoss.js
+++ b/src/utils/physicsUtils/bossUtils/settingBoss.js
@@ -1,6 +1,6 @@
 import entityInfo from "../../../entities/entitiesInfo";
 
-export default settingBoss ({ entities, Matter, bossRound }) {
+export default function settingBoss ({ entities, Matter, bossRound }) {
   if (entities.round === bossRound) {
     const { stage } = entities;
     const { world } = entities.physics;

--- a/src/utils/physicsUtils/bossUtils/translateThrowing.js
+++ b/src/utils/physicsUtils/bossUtils/translateThrowing.js
@@ -1,0 +1,77 @@
+import { Dimensions } from "react-native";
+import { swipe } from "../../../../assets/audio";
+import entityInfo from "../../../entities/entitiesInfo";
+import playAudio from "../../playAudio";
+
+const WINDOW_HEIGHT = Dimensions.get("window").height;
+const FLOOR_WIDTH = 32;
+const GAME_HEIGHT = WINDOW_HEIGHT - FLOOR_WIDTH;
+
+export const throwItems = ({ entities, Matter, entityNum }) => {
+  const { stage } = entities;
+  const player = entities.player.body;
+  const specifics = entityInfo[stage].attack.specifics[entityNum + 1];
+
+  if (specifics.onPosition) {
+    if (specifics.moved === 0) {
+      playAudio(swipe);
+    }
+    Matter.Body.translate(entities[`attack${entityNum + 1}`].body, {
+      x: 0,
+      y: -20,
+    });
+
+    specifics.moved += 20;
+
+    if (specifics.moved > GAME_HEIGHT) {
+      specifics.moved = 0;
+      Matter.Body.setPosition(entities[`attack${entityNum + 1}`].body, {
+        x: player.position.x,
+        y: player.position.y - player.circleRadius,
+      });
+    }
+  }
+};
+
+export const throwMonsters = ({ entities, Matter, entityNum }) => {
+  const { stage } = entities;
+  const player = entities.player.body;
+  const specifics = entityInfo[stage].monster.specifics[entityNum + 1];
+
+  if (specifics.onPosition) {
+    Matter.Body.translate(entities[`monster${entityNum + 1}`].body, {
+      x: 0,
+      y: 7,
+    });
+
+    specifics.moved += 7;
+
+    if (specifics.moved > GAME_HEIGHT) {
+      specifics.moved = 0;
+      Matter.Body.setPosition(entities[`monster${entityNum + 1}`].body, {
+        x: entities.boss1.body.position.x,
+        y: entities.boss1.body.bounds.max.y,
+      });
+    }
+  }
+
+  if (specifics.guideMissile) {
+    Matter.Body.translate(entities[`monster${entityNum + 1}`].body, {
+      x: specifics.guideMissile.x,
+      y: specifics.guideMissile.y,
+    });
+    specifics.moved += specifics.guideMissile.y;
+
+    if (specifics.moved > GAME_HEIGHT) {
+      specifics.moved = 0;
+      Matter.Body.setPosition(entities[`monster${entityNum + 1}`].body, {
+        x: entities.boss1.body.position.x,
+        y: entities.boss1.body.bounds.max.y,
+      });
+      specifics.guideMissile = {
+        x: (player.position.x - entities.boss1.body.position.x) / 40,
+        y: (player.position.y - entities.boss1.body.position.y) / 40,
+      };
+    }
+  }
+};

--- a/src/utils/physicsUtils/translateMapY.js
+++ b/src/utils/physicsUtils/translateMapY.js
@@ -1,5 +1,5 @@
 import { Dimensions } from "react-native";
-import { settingBoss } from "./bossUtills/settingBoss";
+import { settingBoss } from "./bossUtils/settingBoss";
 import { translateEntitiesY } from "./translateEntity";
 import entityInfo from "../../entities/entitiesInfo";
 


### PR DESCRIPTION
1. setThrowItemPositionTimely: 보스 스테이지 진입 시 아이템의 초기 위치를 설정
2. throwMonsters: 보스 스테이지에서 몬스터를 던지는 로직
3. throwItems: 보스 스테이지에서 아이템을 던지는 로직
4. detectAttackCollision: 공격이 보스에 감지됐을 때 상태 변경 로직
5. killMonster: 무적 상태 시 몬스터를 처치하는 로직